### PR TITLE
Make user salt nullable

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -62,7 +62,7 @@ class User implements UserInterface, \Serializable, EquatableInterface
     /**
      * @var string
      *
-     * @ORM\Column(type="string", length=32)
+     * @ORM\Column(type="string", length=32, nullable=true)
      */
     protected $salt;
 


### PR DESCRIPTION
BCrypt stores the salt directly with the hash, so the field is unnecessary in that case.
