### PR TITLE
Add Collection datagrid type

### DIFF
--- a/src/Datagrid/Type/DatagridTypeCollection.php
+++ b/src/Datagrid/Type/DatagridTypeCollection.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Wanjee\Shuwee\AdminBundle\Datagrid\Type;
+use Doctrine\ORM\PersistentCollection;
+
+/**
+ * Class DatagridTypeCollection
+ * @package Wanjee\Shuwee\AdminBundle\Datagrid\Type
+ */
+class DatagridTypeCollection extends DatagridType
+{
+    /**
+     * Get administrative name of this type
+     * @return string Name of the type
+     */
+    public function getName()
+    {
+        return 'datagrid_collection';
+    }
+
+    /**
+     * Get template block name for this type
+     * @return string Block name (must be a valid block name as defined in Twig documentation)
+     */
+    public function getBlockName()
+    {
+        return 'datagrid_collection';
+    }
+
+    /**
+     * Get prepared view parameters
+     *
+     * @param \Wanjee\Shuwee\AdminBundle\Datagrid\Field\DatagridFieldInterface $field
+     * @param mixed $entity Instance of a model entity
+     *
+     * @return mixed
+     */
+    public function getBlockVariables($field, $entity)
+    {
+        $data = $field->getData($entity);
+        $dataArray = [];
+
+        if ($data instanceof \Traversable) {
+            foreach ($data as $element) {
+                $dataArray[] = $element->__toString();
+            }
+        } else {
+            return array(
+              'value' => 'Unsupported.'
+            );
+        }
+
+        $string = join(', ', $dataArray);
+
+        return array(
+          'value' => $string
+        );
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -52,6 +52,11 @@ services:
         tags:
             - { name: shuwee.datagrid_type , alias: boolean}
 
+    shuwee_admin.datagrid_type_collection:
+            class: Wanjee\Shuwee\AdminBundle\Datagrid\Type\DatagridTypeCollection
+            tags:
+                - { name: shuwee.datagrid_type , alias: collection}
+
     shuwee_admin.datagrid_type_image:
         class: Wanjee\Shuwee\AdminBundle\Datagrid\Type\DatagridTypeImage
         tags:

--- a/src/Resources/doc/types.rst
+++ b/src/Resources/doc/types.rst
@@ -64,3 +64,22 @@ You will need to register default Symfony Twig extensions in your main config fi
             class: Twig_Extensions_Extension_Text
             tags:
                 - { name: twig.extension }
+
+Collection
+----------
+
+.. code-block:: php
+
+    ->addField('things', 'collection', array('label' => 'Things'));
+
+Field value is escaped and truncated (80 chars) by default. Your collection must be an array or implement the ``Traversable`` interface, and its elements must have a ``__toString()`` method.
+
+You will need to register default Symfony Twig extensions in your main config file to be able to use this type
+
+.. code-block:: yaml
+
+    services:
+        twig.extension.text:
+            class: Twig_Extensions_Extension_Text
+            tags:
+                - { name: twig.extension }

--- a/src/Resources/views/Datagrid/datagrid.html.twig
+++ b/src/Resources/views/Datagrid/datagrid.html.twig
@@ -74,3 +74,9 @@
     {% endif %}
 {% endblock %}
 
+{% block datagrid_collection %}
+    {% if value is not null %}
+        {{ value | truncate(80) }}
+    {% endif %}
+{% endblock %}
+


### PR DESCRIPTION
Adds support for a collection datagrid type. Elements displayed using this type must either be arrays or implement the `Traversable` interface. The elements contained in the collection must also implement a `__toString()` method.
