### PR TITLE
Feature/entity filter options

### DIFF
--- a/doc/datagrid.md
+++ b/doc/datagrid.md
@@ -363,6 +363,12 @@ Allows you to filter the list on a entity relation.
         'class' => User::class,
         'choice_label' => 'username',
         'placeholder' => 'Choose a user',
+        'query_builder' => function (EntityRepository $er) {
+            return $er->createQueryBuilder('u')
+                ->addOrderBy('u.name', 'ASC')
+                ->addOrderBy('u.version', 'ASC');
+        },
+        'group_by' => 'name',
     ]
 ) 
 ``` 
@@ -372,6 +378,10 @@ Allows you to filter the list on a entity relation.
 * *class*: List of options to display.  Expects string. *Required*. See http://symfony.com/doc/current/reference/forms/types/entity.html#class
 * *choice_label*: Displayed property in the list. See http://symfony.com/doc/current/reference/forms/types/entity.html#choice-label 
 * *placeholder*: This option determines whether or not a special "empty" option will appear at the top of a select widget. Expects string. Defaults to 'All' Shuwee does not allow disabling placeholder. http://symfony.com/doc/current/reference/forms/types/entity.html#placeholder
+* *query_builder*: Allows you to create a custom query for your choices. https://symfony.com/doc/current/reference/forms/types/entity.html#query-builder
+* *group_by*: You can group the option elements of a select into optgroup by passing a multi-dimensional array to choices. https://symfony.com/doc/current/reference/forms/types/entity.html#group-by
+* *em*: If specified, this entity manager will be used to load the choices instead of the default entity manager. https://symfony.com/doc/current/reference/forms/types/entity.html#em
+
 
 ### Known limitations
 

--- a/src/Datagrid/Filter/Type/DatagridFilterTypeEntity.php
+++ b/src/Datagrid/Filter/Type/DatagridFilterTypeEntity.php
@@ -4,6 +4,8 @@ namespace Wanjee\Shuwee\AdminBundle\Datagrid\Filter\Type;
 
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectManager as LegacyObjectManager;
 
 /**
  * Class DatagridFilterTypeEntity
@@ -27,12 +29,23 @@ class DatagridFilterTypeEntity extends DatagridFilterType
             ->setDefined(
                 [
                     'choice_label',
+                    'group_by',
+                    'em',
+                    'query_builder',
                 ]
             )
-            ->setDefault('placeholder', 'All')
+            ->setDefaults([
+                'placeholder' => 'All',
+                'group_by' => null,
+                'em' => null,
+                'query_builder' => null,
+            ])
             ->setAllowedTypes('placeholder', ['string'])
             ->setAllowedTypes('class', ['string'])
-            ->setAllowedTypes('choice_label', ['string', 'callable']);
+            ->setAllowedTypes('choice_label', ['string', 'callable'])
+            ->setAllowedTypes('group_by', ['null', 'string'])
+            ->setAllowedTypes('em', ['null', 'string', ObjectManager::class, LegacyObjectManager::class])
+            ->setAllowedTypes('query_builder', ['null', 'callable', 'Doctrine\ORM\QueryBuilder']);
     }
 
     /**


### PR DESCRIPTION
Add support for group_by, em and query_builder options in DatagridFilterTypeEntity.

Allows custom sorting and grouping of data into the DatagridFilterTypeEntity filter type.